### PR TITLE
refactor(blog): 記事レイアウトを統一しサムネイル画像を冒頭に配置

### DIFF
--- a/articles/0f38e10e85fb6b.md
+++ b/articles/0f38e10e85fb6b.md
@@ -8,9 +8,9 @@ publication_name: 'dress_code'
 published_at: '2025-12-26 00:00'
 ---
 
-## はじめに
-
 ![Dress Code Advent Calendar 2025のグラフィックレコーディング](/images/0f38e10e85fb6b/Gemini_Generated_Image_chv62ochv62ochv6.jpeg)
+
+## はじめに
 
 Dress Code Advent Calendar 2025、無事に25日間完走することができました。
 

--- a/articles/b085b7826f1c56.md
+++ b/articles/b085b7826f1c56.md
@@ -8,13 +8,15 @@ publication_name: 'dress_code'
 published_at: '2025-12-25 00:00'
 ---
 
-Dress Code Advent Calendar 2025 25日目の記事です🎄
-
-https://adventar.org/calendars/12017
+![「壁打ち」をして「壁」を作ろう](/images/b085b7826f1c56/Gemini_Generated_Image_vj97xyvj97xyvj97.jpeg)
 
 ## はじめに
 
 こんにちは。ぷーじ（[@yug1224](https://x.com/yug1224)）です。
+
+Dress Code Advent Calendar 2025 25日目の記事です🎄
+
+https://adventar.org/calendars/12017
 
 この記事では、業務でのプロダクト開発のことではなく、プライベートでAIを活用して子ども部屋の間仕切り壁をDIYした話をお届けします。
 
@@ -215,8 +217,6 @@ _DIY後：間仕切り壁で2つのスペースに_
 OSBボードの質感がいい感じです。将来的にはここにフックを付けたり、棚を付けたりもできそうですね。他の壁との統一感を考えると壁紙を貼っても良いかなと思っています。
 
 ## まとめ
-
-![「壁打ち」をして「壁」を作ろう](/images/b085b7826f1c56/Gemini_Generated_Image_vj97xyvj97xyvj97.jpeg)
 
 今回、Gemini × Nano Banana Proを活用してDIYをしてみて、AIの便利さを改めて実感しました。
 

--- a/articles/d655cd7a43b936.md
+++ b/articles/d655cd7a43b936.md
@@ -8,13 +8,15 @@ publication_name: 'dress_code'
 published_at: '2025-12-24 00:00'
 ---
 
-Dress Code Advent Calendar 2025 24日目の記事です🎄
-
-https://adventar.org/calendars/12017
+![oxlint, oxfmt, tsgoを導入して開発環境が爆速になった](/images/d655cd7a43b936/Gemini_Generated_Image_q270s4q270s4q270.jpeg)
 
 ## はじめに
 
 こんにちは。ぷーじ（[@yug1224](https://x.com/yug1224)）です。
+
+Dress Code Advent Calendar 2025 24日目の記事です🎄
+
+https://adventar.org/calendars/12017
 
 フロントエンド・バックエンド開発において、リンター、フォーマッター、型チェッカーはコード品質を担保する上で欠かせないツールですよね。しかし、プロジェクトの規模が大きくなるにつれ、これらのツールの実行時間がCI/CDのボトルネックになることがあります。
 
@@ -281,8 +283,6 @@ const data = someFunction();
 Type-Aware Lintingは型情報を解析するため、従来よりもメモリ消費が増加します。導入当初はCIがOOM（メモリ不足）でキルされる問題に悩まされました。GitHub Actionsのメモリ制限を8GBに拡張することで解決しましたが、この辺りは環境に合わせた調整が必要です。
 
 ## まとめ
-
-![oxlint, oxfmt, tsgoを導入して開発環境が爆速になった](/images/d655cd7a43b936/Gemini_Generated_Image_q270s4q270s4q270.jpeg)
 
 oxlint、oxfmt、tsgoの導入により、以下の成果を達成しました！
 

--- a/articles/eb8d9afcd86391.md
+++ b/articles/eb8d9afcd86391.md
@@ -8,13 +8,15 @@ publication_name: 'dress_code'
 published_at: '2025-12-24 00:00'
 ---
 
-「エンジニア転職Advent Calendar 2025」24日目の記事です🎄
-
-https://adventar.org/calendars/11370
+![半年間のグラフィックレコーディング](/images/eb8d9afcd86391/Gemini_Generated_Image_liv0ztliv0ztliv0.jpeg)
 
 ## はじめに
 
 こんにちは。ぷーじ（[@yug1224](https://x.com/yug1224)）です。
+
+「エンジニア転職Advent Calendar 2025」24日目の記事です🎄
+
+https://adventar.org/calendars/11370
 
 2025年7月にDress Code株式会社へジョインし、気づけば今月でもう半年。入社1か月時点で書いた振り返り記事では、こんなことを書いていました。
 
@@ -176,8 +178,6 @@ https://biz-journal.jp/company/post_390402.html
 自分としては、プロダクト開発で価値貢献しつつ、**ピープルマネジメントをかけ合わせた領域**で力を発揮していきたいと考えています。EMからICに転身したとはいえ、マネジメント経験は自分の強みの1つ。開発力を取り戻した今だからこそ、その経験を活かせる場面もあるのではと思っています。
 
 ## おわりに
-
-![半年間のグラフィックレコーディング](/images/eb8d9afcd86391/Gemini_Generated_Image_liv0ztliv0ztliv0.jpeg)
 
 5年以上現場から離れていた私が、開発現場に戻った半年間。
 


### PR DESCRIPTION
- サムネイル画像をfrontmatter直後に移動（4記事）
- 自己紹介 → AdCal説明の順序に統一
- まとめ/おわりにセクションから重複画像を削除
