### PR TITLE
docs(blog): QUERY_PRESETS記事の topics を整理

### DIFF
--- a/articles/78ce46997dfe96.md
+++ b/articles/78ce46997dfe96.md
@@ -2,7 +2,7 @@
 title: 'バラバラだった staleTime を、データの性質で選ぶ4プリセットに集約した'
 emoji: '🧩'
 type: 'tech'
-topics: ['tanstackquery', 'react', 'frontend', 'typescript', 'dresscode']
+topics: ['cache', 'frontend', 'react', 'tanstackquery', 'typescript']
 published: true
 published_at: '2026-07-14 12:00'
 publication_name: 'dress_code'


### PR DESCRIPTION
- dresscode を外し cache を追加
- topics をアルファベット順に並べ替え